### PR TITLE
Install yt-dlp in our side instead of postinstall script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --non-interactive --prefer-offline
+        run: YOUTUBE_DL_SKIP_DOWNLOAD=true yarn install --frozen-lockfile --non-interactive --prefer-offline
 
       - name: Run ESLint for frontend
         continue-on-error: true
@@ -152,7 +152,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --non-interactive --prefer-offline
+        run: YOUTUBE_DL_SKIP_DOWNLOAD=true yarn install --frozen-lockfile --non-interactive --prefer-offline
 
       - name: Prepare for tests
         id: prepare
@@ -330,7 +330,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --non-interactive --prefer-offline
+        run: YOUTUBE_DL_SKIP_DOWNLOAD=true yarn install --frozen-lockfile --non-interactive --prefer-offline
 
       - name: Install playwright dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:23-alpine AS base
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat ffmpeg python3 py3-pip
+RUN apk add --no-cache libc6-compat ffmpeg yt-dlp
 
 # Install dependencies
 FROM base AS deps
@@ -14,7 +14,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json yarn.lock .npmrc* ./
-RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn --frozen-lockfile --prefer-offline
+RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn YOUTUBE_DL_SKIP_DOWNLOAD=true yarn --frozen-lockfile --prefer-offline
 
 # Rebuild the source code only when needed
 FROM deps AS builder


### PR DESCRIPTION
## Description
<!-- Describe the changes made in this pull request. -->
<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Fixes error when GitHub is rate-limiting the API in CI (https://github.com/talkarr/talkarr/actions/runs/13369909916/job/37335951686).

Also lets us pin-point a specific yt-dlp version if needed.