### PR TITLE
Add curl dependency so health check does not fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat ffmpeg yt-dlp \
-    pkgconfig pixman build-base g++ cairo-dev pango-dev giflib-dev git
+    pkgconfig pixman build-base g++ cairo-dev pango-dev giflib-dev git curl
 
 # Install dependencies
 FROM base AS deps


### PR DESCRIPTION
## Description
Right now the health check from docker is failing. The reason is that it is using curl, which previously was not installed inside the container. This should fix it and make it "healthy"