### PR TITLE
Fix unwanted creation of root folders in case of direct api call

### DIFF
--- a/backend/events.ts
+++ b/backend/events.ts
@@ -101,13 +101,8 @@ export const addTalk = async ({
                     })),
                 },
                 root_folder: {
-                    connectOrCreate: {
-                        where: {
-                            path: rootFolder,
-                        },
-                        create: {
-                            path: rootFolder,
-                        },
+                    connect: {
+                        path: rootFolder,
                     },
                 },
                 poster_url: event.poster_url,


### PR DESCRIPTION
## Description
<!-- Describe the changes made in this pull request. -->
<!-- If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Fixes a bug where a user could send invalid data (for example a root folder path that was not available in the selector) that would then create a new database entry instead of failing because the root folder does not exist

All create() calls for root folders should be only in the correct methods that ensure proper database and OS state is given