### PR TITLE
Improve performance by using Promise.all() instead of for await ()

### DIFF
--- a/backend/api/talks/scan.ts
+++ b/backend/api/talks/scan.ts
@@ -49,11 +49,12 @@ const handleScanEventsRequest = async (
 
     const mappedFiles: components['schemas']['ExtendedFileWithGuess'][] = [];
 
-    for await (const rootFolderPath of foldersToScan) {
-        const files = (await scanForExistingFiles({ rootFolderPath })) ?? [];
+    const scanFolder = async (folderPath: string): Promise<void> => {
+        const files =
+            (await scanForExistingFiles({ rootFolderPath: folderPath })) ?? [];
 
         if (files.length === 0) {
-            continue;
+            return;
         }
 
         const mapped = files.map<
@@ -78,7 +79,9 @@ const handleScanEventsRequest = async (
         );
 
         mappedFiles.push(...mapped);
-    }
+    };
+
+    await Promise.all(foldersToScan.map(folderPath => scanFolder(folderPath)));
 
     res.json({
         success: true,

--- a/backend/events.ts
+++ b/backend/events.ts
@@ -1143,13 +1143,17 @@ export const importEventFahrplanJson = async ({
     slugsToImport = [...new Set(slugsToImport)];
 
     // check with getSpecificTalkBySlug if the talk already exists
-    for await (const slug of slugsToImport) {
-        const existingTalk = await getSpecificTalkBySlug({ slug });
+    await Promise.all(
+        slugsToImport.map(async slug => {
+            const existingTalk = await getSpecificTalkBySlug({
+                slug,
+            });
 
-        if (existingTalk) {
-            existingImports.push(slug);
-        }
-    }
+            if (existingTalk) {
+                existingImports.push(slug);
+            }
+        }),
+    );
 
     slugsToImport = slugsToImport.filter(
         slug => !existingImports.includes(slug),

--- a/backend/workers/scan-and-import-existing-files.ts
+++ b/backend/workers/scan-and-import-existing-files.ts
@@ -60,14 +60,16 @@ const scanAndImportExistingFiles: TaskFunction = async (job, done) => {
 
         log.info('Found new files:', { files: scanResult.length });
 
-        for await (const file of scanResult) {
+        const handleImportFile = async (
+            file: (typeof scanResult)[number],
+        ): Promise<void> => {
             if (file.guess.confidence !== 100) {
                 log.warn('File has too low confidence:', {
                     file: file.filename,
                     confidence: file.guess.confidence,
                 });
 
-                continue;
+                return;
             }
 
             log.info('Importing file...', { file: file.filename });
@@ -85,7 +87,11 @@ const scanAndImportExistingFiles: TaskFunction = async (job, done) => {
                     { file: file.filename },
                 );
             }
-        }
+        };
+
+        await Promise.all(
+            scanResult.map(scanFile => handleImportFile(scanFile)),
+        );
     }
 
     done();


### PR DESCRIPTION
## Description
By using `Promise.all()`, multiple calls can run at the same time. This should only done where it makes sense, as some `for await()` are intended for sequential execution